### PR TITLE
BUGFIX: Filtering by Expired

### DIFF
--- a/code/controller/TimedNoticeAdmin.php
+++ b/code/controller/TimedNoticeAdmin.php
@@ -74,7 +74,7 @@ class TimedNoticeAdmin extends ModelAdmin
                 $now = date('Y-m-d H:i:s');
                 if ($status == 'Future') {
                     return $list->where("StartTime > '$now'");
-                } elseif ($status == 'Past') {
+                } elseif ($status == 'Expired') {
                     return $list->where("EndTime < $now");
                 } elseif ($status == 'Current') {
                     return $list->where("


### PR DESCRIPTION
Expired filtering wasn't work because it was trying to match it against the string 'Past' instead of "Expired".