### PR TITLE
Context depended notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,32 @@
-#Silverstripe Timed Notices
+# Silverstripe Timed Notices
 
-Allows CMS users to create and display notices to other CMS users for the duration of a specified time period. Notices can be made visible to any logged in users or only people from specified user groups.
+Allows CMS users to create and display notices for a specified time period. Notices can be displayed depending on the context of the user. Either to website visitors or other CMS users. Notices can be made visible to anyone, any logged in users or only people from specified user groups.
 
-##Example
+## Example
 
 ![Screenshot](https://raw.github.com/sheadawson/silverstripe-timednotices/master/images/screenshot.png)
 
-##Requirements
+## Requirements
 
 SilverStripe ~3.1 (see 3.0 branch for ~3.0 compatible version)
 
-##Install
+## Installation and set up
 
 ```
 composer require sheadawson/silverstripe-timednotices
 php ./framework/cli-script.php dev/build flush=all
 ```
 
-##TODO
+If you are intending to use the notices on your website you have to take care of the following two steps:
 
-* Add a "Context" option to Timed Notice, allowing notices to be displayed in the cms or frontend, rather than just cms
+1.) Add ```$Notices``` to your templates/Page.ss file.
 
+2.) Add suitable styles to your SASS/LESS/CSS. The following example shows the used markup:
+
+```
+<div class="message good">A successful message</div>
+
+<div class="message warning">A warning</div>
+
+<div class="message bad">A bad message</div>
+```

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,7 +7,9 @@ After:
 Director:
   rules:
    'timednotice//$Action/$ID/$OtherID': 'TimedNoticeController'
-
+Page:
+  extensions:
+    - TimedNoticedPageExtension
 LeftAndMain:
   extra_requirements_javascript:
     - 'timednotices/javascript/timednotices-cms.js'

--- a/code/extension/TimedNoticedPageExtension.php
+++ b/code/extension/TimedNoticedPageExtension.php
@@ -1,0 +1,6 @@
+<?php
+
+class TimedNoticedPageExtension extends DataExtension
+{
+
+}

--- a/code/extension/TimedNoticedPageExtension.php
+++ b/code/extension/TimedNoticedPageExtension.php
@@ -2,5 +2,16 @@
 
 class TimedNoticedPageExtension extends DataExtension
 {
-
+    /**
+     * Gets any notices relevant to the present time, context and current users
+     *
+     * @return HTMLText
+     **/
+    public function notices()
+    {
+        // render a list of notications for this
+        return $this->owner
+            ->customise(array('Notices' => TimedNotice::getNotices()))
+            ->renderWith('NoticesList');
+    }
 }

--- a/code/model/TimedNotice.php
+++ b/code/model/TimedNotice.php
@@ -203,7 +203,7 @@ class TimedNotice extends DataObject implements PermissionProvider
         ));
     }
 
-    public static function add_notice($message, $end, $start = null, $type = 'good', $viewBy = null)
+    public static function add_notice($message, $context, $end, $start = null, $type = 'good', $viewBy = null)
     {
         if (!$start) {
             $start = SS_Datetime::now()->getValue();
@@ -215,6 +215,7 @@ class TimedNotice extends DataObject implements PermissionProvider
 
         $notice = TimedNotice::create(array(
             'Message'        => $message,
+            'Context'        => $context,
             'StartTime'      => $start,
             'EndTime'        => $end,
             'CanViewType'    => 'LoggedInUsers',

--- a/templates/Includes/NoticesList.ss
+++ b/templates/Includes/NoticesList.ss
@@ -1,0 +1,3 @@
+<% loop $Notices %>
+    <div class="message $MessageType">$Message</div>
+<% end_loop %>


### PR DESCRIPTION
* notices can either be displayed on the website or on the CMS. Website notices are for anyone, logged in users or particular groups (as before).
* CMS notices will never be delivered to not-logged in users (security reasons)
* minor refactoring.