### PR TITLE
Bugfix: Updated config.yml to register assets, update namespacing.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,8 +4,10 @@ After: 'rootroutes'
 ---
 SilverStripe\Control\Director:
   rules:
-   'timednotice//$Action/$ID/$OtherID': MBIE\TimedNotice\TimedNoticeController
+   'timednotice//$Action/$ID/$OtherID': SheaDawson\TimedNotice\TimedNoticeController
 
 SilverStripe\Admin\LeftAndMain:
-  extra_requirements_javascript: 'silverstripe-timednotices/javascript/timednotices-cms.js'
-  extra_requirements_css: 'silverstripe-timednotices/css/timednotices-cms.css'
+  extra_requirements_javascript:
+    - 'sheadawson/silverstripe-timednotices: javascript/timednotices-cms.js'
+  extra_requirements_css:
+    - 'sheadawson/silverstripe-timednotices: css/timednotices-cms.css'

--- a/code/controller/TimedNoticeAdmin.php
+++ b/code/controller/TimedNoticeAdmin.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace MBIE\TimedNotice;
+namespace SheaDawson\TimedNotice;
 
-use MBIE\TimedNotice\TimedNotice;
+use SheaDawson\TimedNotice\TimedNotice;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\DropdownField;

--- a/code/controller/TimedNoticeController.php
+++ b/code/controller/TimedNoticeController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace MBIE\TimedNotice;
+namespace SheaDawson\TimedNotice;
 
-use MBIE\TimedNotice\TimedNotice;
+use SheaDawson\TimedNotice\TimedNotice;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Convert;
 use SilverStripe\ORM\FieldType\DBDatetime;

--- a/code/model/TimedNotice.php
+++ b/code/model/TimedNotice.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MBIE\TimedNotice;
+namespace SheaDawson\TimedNotice;
 
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\ListboxField;


### PR DESCRIPTION
Hi @sheadawson,

It seems that the original upgrade to SS4 had the config.yml configured incorrectly. So this is to update the config to pull in the js and css through to the CMS. It also updates the namespacing by removing the prefix `MBIE` and replacing it with `SheaDawson` to match the package name.

Cheers!